### PR TITLE
Fix: Ignore updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,6 +16,11 @@ update_configs:
     default_reviewers:
       - "localheinz"
     directory: "/"
+    ignored_updates:
+      - match:
+          dependency_name: "phpunit/phpunit"
+      - match:
+          dependency_name: "sebastian/diff"
     package_manager: "php:composer"
     update_schedule: "live"
     version_requirement_updates: "increase_versions"


### PR DESCRIPTION
This PR

* [x] adjusts the Dependabot configuration to ignore updates for `phpunit/phpunit` and `sebastian/diff`