### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpunit-framework-constraint
+ * @see https://github.com/ergebnis/phpunit-framework-constraint
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2018 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/phpunit-framework-constraint
+@see https://github.com/ergebnis/phpunit-framework-constraint
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.1.0...master`][0.1.0...master].
+For a full diff see [`0.2.0...master`][0.2.0...master].
+
+## [`0.2.0`][0.2.0]
+
+For a full diff see [`0.1.0...0.2.0`][0.1.0...0.2.0].
 
 ### Changed
 
 * Required `phpunit/phpunit:^8.5.0` ([#10]), by [@localheinz]
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#20]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/phpunit-framework-constraint
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/phpunit-framework-constraint
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\PHPUnit\\Framework\\Constraint/Ergebnos\\PHPUnit\\Framework\\Constraint/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\PHPUnit\Framework\Constraint` with `Ergebnis\PHPUnit\Framework\Constraint`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -22,14 +57,19 @@ For a full diff see [`49693ce...0.1.0`][49693ce...0.1.0].
 
 ### Added
 
-* Added `JsonIdentical` constraint [(#1]), by [@localheinz]
+* Added `JsonIdentical` constraint ([#1]), by [@localheinz]
 
-[0.1.0]: https://github.com/localheinz/phpunit-framework-constraint/releases/tag/0.1.0
+[0.1.0]: https://github.com/ergebnis/phpunit-framework-constraint/releases/tag/0.1.0
+[0.2.0]: https://github.com/ergebnis/phpunit-framework-constraint/releases/tag/0.2.0
 
-[49693ce...0.1.0]: https://github.com/localheinz/phpunit-framework-constraint/compare/49693ce...0.1.0
-[0.1.0...master]: https://github.com/localheinz/phpunit-framework-constraint/compare/0.1.0...master
+[49693ce...0.1.0]: https://github.com/ergebnis/phpunit-framework-constraint/compare/49693ce...0.1.0
+[0.1.0...0.2.0]: https://github.com/ergebnis/phpunit-framework-constraint/compare/0.1.0...0.2.0
+[0.2.0...master]: https://github.com/ergebnis/phpunit-framework-constraint/compare/0.2.0...master
 
-[#8]: https://github.com/localheinz/phpunit-framework-constraint/pull/8
-[#10]: https://github.com/localheinz/phpunit-framework-constraint/pull/10
+[#1]: https://github.com/ergebnis/phpunit-framework-constraint/pull/1
+[#8]: https://github.com/ergebnis/phpunit-framework-constraint/pull/8
+[#10]: https://github.com/ergebnis/phpunit-framework-constraint/pull/10
+[#20]: https://github.com/ergebnis/phpunit-framework-constraint/pull/20
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # phpunit-framework-constraint
 
-[![Continuous Integration](https://github.com/localheinz/phpunit-framework-constraint/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/phpunit-framework-constraintactions)
-[![Code Coverage](https://codecov.io/gh/localheinz/phpunit-framework-constraint/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/phpunit-framework-constraint)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/phpunit-framework-constraint/v/stable)](https://packagist.org/packages/localheinz/phpunit-framework-constraint)
-[![Total Downloads](https://poser.pugx.org/localheinz/phpunit-framework-constraint/downloads)](https://packagist.org/packages/localheinz/phpunit-framework-constraint)
+[![Continuous Integration](https://github.com/ergebnis/phpunit-framework-constraint/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/phpunit-framework-constraintactions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/phpunit-framework-constraint/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/phpunit-framework-constraint)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/phpunit-framework-constraint/v/stable)](https://packagist.org/packages/ergebnis/phpunit-framework-constraint)
+[![Total Downloads](https://poser.pugx.org/ergebnis/phpunit-framework-constraint/downloads)](https://packagist.org/packages/ergebnis/phpunit-framework-constraint)
 
 Provides additional constraints for [`phpunit/phpunit`](https://github.com/sebastianbergmann/phpunit).
 
@@ -12,12 +12,12 @@ Provides additional constraints for [`phpunit/phpunit`](https://github.com/sebas
 Run
 
 ```
-$ composer require localheinz/phpunit-framework-constraint
+$ composer require ergebnis/phpunit-framework-constraint
 ```
 
 ## Usage
 
-Import the `Localheinz\PHPUnit\Framework\Constraint\Provider` trait into your test class:
+Import the `Ergebnis\PHPUnit\Framework\Constraint\Provider` trait into your test class:
 
 ```php
 <?php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace Foo\Bar\Test\Unit;
 
-use Localheinz\PHPUnit\Framework\Constraint\Provider;
+use Ergebnis\PHPUnit\Framework\Constraint\Provider;
 use PHPUnit\Framework\TestCase;
 
 final class BazTest extends TestCase

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/phpunit-framework-constraint",
+  "name": "ergebnis/phpunit-framework-constraint",
   "type": "library",
   "description": "Provides additional constraints and assertions for phpunit/phpunit",
   "keywords": [
@@ -7,7 +7,7 @@
     "assertion",
     "constraint"
   ],
-  "homepage": "https://github.com/localheinz/phpunit-framework-constraint",
+  "homepage": "https://github.com/ergebnis/phpunit-framework-constraint",
   "license": "MIT",
   "authors": [
     {
@@ -37,16 +37,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\PHPUnit\\Framework\\Constraint\\": "src/"
+      "Ergebnis\\PHPUnit\\Framework\\Constraint\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\PHPUnit\\Framework\\Constraint\\Test\\": "test/"
+      "Ergebnis\\PHPUnit\\Framework\\Constraint\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/phpunit-framework-constraint/issues",
-    "source": "https://github.com/localheinz/phpunit-framework-constraint"
+    "issues": "https://github.com/ergebnis/phpunit-framework-constraint/issues",
+    "source": "https://github.com/ergebnis/phpunit-framework-constraint"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "226b8096901736999a5d367467091672",
+    "content-hash": "86f0ab1bb8465761a1dbce85859f4e50",
     "packages": [
         {
             "name": "doctrine/instantiator",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,7 +3,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Localheinz\\\\PHPUnit\\\\Framework\\\\Constraint\\\\Test\\\\Unit\\\\ProviderTest\\:\\:assertJsonStringSameAsJsonString\\(\\) is protected, but since the containing class is final, it can be private\\.$#"
+			message: "#^Method Ergebnis\\\\PHPUnit\\\\Framework\\\\Constraint\\\\Test\\\\Unit\\\\ProviderTest\\:\\:assertJsonStringSameAsJsonString\\(\\) is protected, but since the containing class is final, it can be private\\.$#"
 			count: 1
 			path: test/Unit/ProviderTest.php
 

--- a/src/IsIdenticalJson.php
+++ b/src/IsIdenticalJson.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpunit-framework-constraint
+ * @see https://github.com/ergebnis/phpunit-framework-constraint
  */
 
-namespace Localheinz\PHPUnit\Framework\Constraint;
+namespace Ergebnis\PHPUnit\Framework\Constraint;
 
 use PHPUnit\Framework;
 use SebastianBergmann\Diff;

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpunit-framework-constraint
+ * @see https://github.com/ergebnis/phpunit-framework-constraint
  */
 
-namespace Localheinz\PHPUnit\Framework\Constraint;
+namespace Ergebnis\PHPUnit\Framework\Constraint;
 
 trait Provider
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpunit-framework-constraint
+ * @see https://github.com/ergebnis/phpunit-framework-constraint
  */
 
-namespace Localheinz\PHPUnit\Framework\Constraint\Test\AutoReview;
+namespace Ergebnis\PHPUnit\Framework\Constraint\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\PHPUnit\\Framework\\Constraint\\',
-            'Localheinz\\PHPUnit\\Framework\\Constraint\\Test\\Unit\\'
+            'Ergebnis\\PHPUnit\\Framework\\Constraint\\',
+            'Ergebnis\\PHPUnit\\Framework\\Constraint\\Test\\Unit\\'
         );
     }
 }

--- a/test/Unit/IsIdenticalJsonTest.php
+++ b/test/Unit/IsIdenticalJsonTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpunit-framework-constraint
+ * @see https://github.com/ergebnis/phpunit-framework-constraint
  */
 
-namespace Localheinz\PHPUnit\Framework\Constraint\Test\Unit;
+namespace Ergebnis\PHPUnit\Framework\Constraint\Test\Unit;
 
+use Ergebnis\PHPUnit\Framework\Constraint\IsIdenticalJson;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\PHPUnit\Framework\Constraint\IsIdenticalJson;
 use PHPUnit\Framework;
 use SebastianBergmann\Exporter;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPUnit\Framework\Constraint\IsIdenticalJson
+ * @covers \Ergebnis\PHPUnit\Framework\Constraint\IsIdenticalJson
  */
 final class IsIdenticalJsonTest extends Framework\TestCase
 {

--- a/test/Unit/ProviderTest.php
+++ b/test/Unit/ProviderTest.php
@@ -8,21 +8,21 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpunit-framework-constraint
+ * @see https://github.com/ergebnis/phpunit-framework-constraint
  */
 
-namespace Localheinz\PHPUnit\Framework\Constraint\Test\Unit;
+namespace Ergebnis\PHPUnit\Framework\Constraint\Test\Unit;
 
+use Ergebnis\PHPUnit\Framework\Constraint\Provider;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\PHPUnit\Framework\Constraint\Provider;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPUnit\Framework\Constraint\Provider
+ * @covers \Ergebnis\PHPUnit\Framework\Constraint\Provider
  *
- * @uses \Localheinz\PHPUnit\Framework\Constraint\IsIdenticalJson
+ * @uses \Ergebnis\PHPUnit\Framework\Constraint\IsIdenticalJson
  */
 final class ProviderTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis