### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.2.0...master`][0.2.0...master].
+For a full diff see [`0.2.1...master`][0.2.1...master].
+
+## [`0.2.1`][0.2.1]
+
+For a full diff see [`0.2.0...0.2.1`][0.2.0...0.2.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#23]), by [@localheinz]
 
 ## [`0.2.0`][0.2.0]
 
@@ -61,15 +69,18 @@ For a full diff see [`49693ce...0.1.0`][49693ce...0.1.0].
 
 [0.1.0]: https://github.com/ergebnis/phpunit-framework-constraint/releases/tag/0.1.0
 [0.2.0]: https://github.com/ergebnis/phpunit-framework-constraint/releases/tag/0.2.0
+[0.2.1]: https://github.com/ergebnis/phpunit-framework-constraint/releases/tag/0.2.1
 
 [49693ce...0.1.0]: https://github.com/ergebnis/phpunit-framework-constraint/compare/49693ce...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/phpunit-framework-constraint/compare/0.1.0...0.2.0
-[0.2.0...master]: https://github.com/ergebnis/phpunit-framework-constraint/compare/0.2.0...master
+[0.2.0...0.2.1]: https://github.com/ergebnis/phpunit-framework-constraint/compare/0.2.0...0.2.1
+[0.2.1...master]: https://github.com/ergebnis/phpunit-framework-constraint/compare/0.2.1...master
 
 [#1]: https://github.com/ergebnis/phpunit-framework-constraint/pull/1
 [#8]: https://github.com/ergebnis/phpunit-framework-constraint/pull/8
 [#10]: https://github.com/ergebnis/phpunit-framework-constraint/pull/10
 [#20]: https://github.com/ergebnis/phpunit-framework-constraint/pull/20
+[#23]: https://github.com/ergebnis/phpunit-framework-constraint/pull/23
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
     "phpunit/phpunit": "^8.5.0",
     "sebastian/diff": "^3.0.2"
   },
-  "replace": {
-    "localheinz/phpunit-framework-constraint": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79afc517669c27f48f936b82888c6020",
+    "content-hash": "86f0ab1bb8465761a1dbce85859f4e50",
     "packages": [
         {
             "name": "doctrine/instantiator",


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #20.